### PR TITLE
(feat)docker: add ninja meson and irssi to Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -44,6 +44,9 @@ RUN apt-get update && \
     clangd \
     gdb \
     lldb-12 \
+    irssi \
+    netcat \
+    meson ninja-build \
     gcc-10=10.5.0-1ubuntu1~22.04.2 \
     g++-10=10.5.0-1ubuntu1~22.04.2 \
     gcc-11=11.4.0-1ubuntu1~22.04.2 \


### PR DESCRIPTION
Add Meson, Ninja (ninja-build) and Irssi to the development Dockerfile. Meson and Ninja are required build tools for several projects; Irssi is included as a lightweight terminal IRC client for development and debugging tasks. The Dockerfile installs these packages and performs package list cleanup to minimize image size.